### PR TITLE
fix(ci): use composite actions for Go build cache

### DIFF
--- a/.github/actions/setup-go-with-cache/action.yml
+++ b/.github/actions/setup-go-with-cache/action.yml
@@ -1,0 +1,30 @@
+name: 'Set up Go'
+description: 'Install Go and set up cache'
+inputs:
+  cache-key-prefix:
+    description: 'Cache key prefix'
+    required: false
+    default: setup-go-with-cache-${{ github.workflow }}-${{ github.job }}
+runs:
+  using: composite
+  steps:
+    - name: Install Go
+      uses: actions/setup-go@v3.2.0
+      with:
+        go-version-file: .go-version
+    - name: Get Go cache paths
+      id: go-cache
+      shell: bash
+      run: |
+        echo "::set-output name=cache::$(go env GOCACHE)"
+        echo "::set-output name=modcache::$(go env GOMODCACHE)"
+    - name: Set up Go cache
+      uses: actions/cache@v3.0.2
+      with:
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ github.run_id }}-
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-
+        path: |
+          ${{ steps.go-cache.outputs.cache }}
+          ${{ steps.go-cache.outputs.modcache }}

--- a/.github/actions/setup-golangci-lint/action.yml
+++ b/.github/actions/setup-golangci-lint/action.yml
@@ -1,0 +1,27 @@
+name: 'Set up golangci-lint'
+description: 'Install golangci-lint and set up cache'
+inputs:
+  cache-key-prefix:
+    description: 'Cache key prefix'
+    required: false
+    default: setup-golangci-lint-${{ github.workflow }}-${{ github.job }}
+runs:
+  using: composite
+  steps:
+    - name: Install golangci-lint
+      shell: bash
+      run: |
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+    - name: Get golangci-lint cache path
+      id: golangci-lint-cache-status
+      shell: bash
+      run: |
+        echo "::set-output name=dir::$(golangci-lint cache status | head -1 | sed 's/^Dir: //')"
+    - name: Set up golangci-lint cache
+      uses: actions/cache@v3.0.2
+      with:
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ github.run_id }}-
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-
+        path: ${{ steps.golangci-lint-cache-status.outputs.dir }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     schedule:
       interval: daily
 
+  # See https://github.com/dependabot/dependabot-core/issues/4178#issuecomment-1118492006
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/setup-go-with-cache"
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/setup-golangci-lint"
+    schedule:
+      interval: daily
+
   # find . -name go.mod | sort | sed 's/^\.\(.*\)\/go.mod$/  - package-ecosystem: gomod\n    directory: "\1"\n    schedule:\n      interval: daily/'
   - package-ecosystem: gomod
     directory: "/awsenv"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up Go
-        uses: actions/setup-go@v3.2.0
-        with:
-          go-version-file: .go-version
-          cache: true
-          cache-dependency-path: '**/go.sum'
+        uses: ./.github/actions/setup-go-with-cache
       - name: Run tests
         run: go test -race go.pact.im/x/...

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -21,11 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up Go
-        uses: actions/setup-go@v3.2.0
-        with:
-          go-version-file: .go-version
-          cache: true
-          cache-dependency-path: '**/go.sum'
+        uses: ./.github/actions/setup-go-with-cache
       - name: Update dependencies
         run: |
           goget() {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,23 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up Go
-        uses: actions/setup-go@v3.2.0
-        with:
-          go-version-file: .go-version
-          cache: true
-          cache-dependency-path: '**/go.sum'
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
-      - name: Get golangci-lint cache path
-        id: golangci-lint-cache-status
-        run: |
-          echo "::set-output name=dir::$(golangci-lint cache status | head -1 | sed 's/^Dir: //')"
-      - name: Set up golangci-lint cache
-        uses: actions/cache@v3.0.2
-        with:
-          key: golangci-lint-${{ runner.os }}-golangci-lint-${{ hashFiles('**/go.mod') }}
-          restore-keys: golangci-lint-${{ runner.os }}-golangci-lint-
-          path: ${{ steps.golangci-lint-cache-status.outputs.dir }}
+        uses: ./.github/actions/setup-go-with-cache
+      - name: Set up golangci-lint
+        uses: ./.github/actions/setup-golangci-lint
       - name: Run golangci-lint
         run: |
           golangci-lint run --out-format=github-actions -- \

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,11 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up Go
-        uses: actions/setup-go@v3.2.0
-        with:
-          go-version-file: .go-version
-          cache: true
-          cache-dependency-path: '**/go.sum'
+        uses: ./.github/actions/setup-go-with-cache
       - name: Install vangen
         run: go install 4d63.com/vangen@v1.2.0
       - name: Install golds

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -11,11 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up Go
-        uses: actions/setup-go@v3.2.0
-        with:
-          go-version-file: .go-version
-          cache: true
-          cache-dependency-path: '**/go.sum'
+        uses: ./.github/actions/setup-go-with-cache
       - name: Install mockgen
         run: go install github.com/golang/mock/mockgen@v1.6.0
       - name: Run go mod tidy


### PR DESCRIPTION
This PR switches from `actions/setup-go` cache (see https://github.com/actions/setup-go/pull/228) to explicit `actions/cache` since the former does not allow specifying cache key or *at least* a key prefix. This is an issue when multiple distinct jobs and workflows use Go cache for different purposes (e.g. run tests, install tools and build docs) and therefore sharing it under the same key makes no sense (and, in fact, breaks caching since the results have to be recomputed).
